### PR TITLE
Fixed image type for song meta-data

### DIFF
--- a/conversion_utils.py
+++ b/conversion_utils.py
@@ -1,6 +1,9 @@
 import os
 import music_tag
 
+from PIL import Image
+from pathlib import Path
+
 
 def convert_to_m4a(location_mp4: str, location_m4a: str):
     """
@@ -21,7 +24,6 @@ def clean_temp_folder(location_mp4_tempdir: str) -> None:
     print("Removing temporary mp4 files (pass -k to keep)")
     for subdir, dirs, files in os.walk(location_mp4_tempdir):
         for file in files:
-            print(file.title())
             if file.title() == ".Gitkeep":
                 continue
             print("Removing " + os.path.join(subdir, file))
@@ -34,9 +36,14 @@ def set_meta_tags(location_m4a: str, title: str, author: str, jpg_path: str) -> 
     file['title'] = title
     file['artist'] = author
 
+    # Convert the jpg picture to png (music-tag package wants this for some reason)
+    png_path = Path(jpg_path).with_suffix(".png")
+    jpg_img = Image.open(jpg_path)
+    jpg_img.save(png_path)
+
     # Set the cover image if provided (suppressed by -nocover)
-    if os.path.isfile(jpg_path) or jpg_path != "NONE":
-        with open(jpg_path, 'rb') as img_in:
+    if os.path.isfile(png_path) or png_path != "NONE":
+        with open(png_path, 'rb') as img_in:
             file['artwork'] = img_in.read()
 
     file.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ youtube-search-python==1.6.6
 music-tag==0.4.3
 configparser~=5.3.0
 requests~=2.28.2
+Pillow~=9.4.0


### PR DESCRIPTION
The image type for the meta-tags package needs to be jpeg or png. Youtube images are jpg. Using pillow we can create another temporary file to turn the jpg into a png.